### PR TITLE
refactor: return original error to consumer

### DIFF
--- a/wallet_manager.go
+++ b/wallet_manager.go
@@ -774,7 +774,7 @@ func (wm *WalletManager) EnsureTxWithHooks(
 		}
 	}
 
-	return nil, ErrEnsureTxOutOfRetries
+	return nil, errors.Join(ErrEnsureTxOutOfRetries, err)
 }
 
 func (wm *WalletManager) EnsureTx(


### PR DESCRIPTION
We need to return the original error to the consumer code so that we can decode custom Solidity error at the consumer code level