### PR TITLE
refactor: expose api with builder pattern but keep the behavior of EnsureTx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.2
 require (
 	github.com/KyberNetwork/logger v0.2.1
 	github.com/ethereum/go-ethereum v1.14.12
+	github.com/stretchr/testify v1.9.0
 	github.com/tranvictor/jarvis v0.0.32
 )
 
@@ -28,6 +29,7 @@ require (
 	github.com/couchbase/vellum v1.0.2 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c // indirect
 	github.com/crate-crypto/go-kzg-4844 v1.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/ethereum/c-kzg-4844 v1.0.0 // indirect
@@ -46,6 +48,7 @@ require (
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/openconfig/goyang v0.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
@@ -66,5 +69,6 @@ require (
 	golang.org/x/term v0.28.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/request.go
+++ b/request.go
@@ -1,0 +1,161 @@
+package walletarmy
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/tranvictor/jarvis/networks"
+)
+
+// TxRequest represents a transaction request with builder pattern
+type TxRequest struct {
+	wm *WalletManager
+
+	numRetries    int
+	sleepDuration time.Duration
+
+	// Transaction parameters
+	txType          uint8
+	from, to        common.Address
+	value           *big.Int
+	gasLimit        uint64
+	extraGasLimit   uint64
+	gasPrice        float64
+	extraGasPrice   float64
+	tipCapGwei      float64
+	extraTipCapGwei float64
+	data            []byte
+	network         networks.Network
+
+	// Hooks
+	beforeSignAndBroadcastHook Hook
+	afterSignAndBroadcastHook  Hook
+}
+
+// R creates a new transaction request (similar to go-resty's R() method)
+func (wm *WalletManager) R() *TxRequest {
+	return &TxRequest{
+		wm:      wm,
+		value:   big.NewInt(0),            // default value
+		network: networks.EthereumMainnet, // default network is Ethereum Mainnet
+	}
+}
+
+// SetNumRetries sets the number of retries
+func (r *TxRequest) SetNumRetries(numRetries int) *TxRequest {
+	r.numRetries = numRetries
+	return r
+}
+
+// SetSleepDuration sets the sleep duration
+func (r *TxRequest) SetSleepDuration(sleepDuration time.Duration) *TxRequest {
+	r.sleepDuration = sleepDuration
+	return r
+}
+
+// SetTxType sets the transaction type
+func (r *TxRequest) SetTxType(txType uint8) *TxRequest {
+	r.txType = txType
+	return r
+}
+
+// SetFrom sets the from address
+func (r *TxRequest) SetFrom(from common.Address) *TxRequest {
+	r.from = from
+	return r
+}
+
+// SetTo sets the to address
+func (r *TxRequest) SetTo(to common.Address) *TxRequest {
+	r.to = to
+	return r
+}
+
+// SetValue sets the transaction value
+func (r *TxRequest) SetValue(value *big.Int) *TxRequest {
+	if value != nil {
+		r.value = value
+	}
+	return r
+}
+
+// SetGasLimit sets the gas limit
+func (r *TxRequest) SetGasLimit(gasLimit uint64) *TxRequest {
+	r.gasLimit = gasLimit
+	return r
+}
+
+// SetExtraGasLimit sets the extra gas limit
+func (r *TxRequest) SetExtraGasLimit(extraGasLimit uint64) *TxRequest {
+	r.extraGasLimit = extraGasLimit
+	return r
+}
+
+// SetGasPrice sets the gas price
+func (r *TxRequest) SetGasPrice(gasPrice float64) *TxRequest {
+	r.gasPrice = gasPrice
+	return r
+}
+
+// SetExtraGasPrice sets the extra gas price
+func (r *TxRequest) SetExtraGasPrice(extraGasPrice float64) *TxRequest {
+	r.extraGasPrice = extraGasPrice
+	return r
+}
+
+// SetTipCapGwei sets the tip cap in gwei
+func (r *TxRequest) SetTipCapGwei(tipCapGwei float64) *TxRequest {
+	r.tipCapGwei = tipCapGwei
+	return r
+}
+
+// SetExtraTipCapGwei sets the extra tip cap in gwei
+func (r *TxRequest) SetExtraTipCapGwei(extraTipCapGwei float64) *TxRequest {
+	r.extraTipCapGwei = extraTipCapGwei
+	return r
+}
+
+// SetData sets the transaction data
+func (r *TxRequest) SetData(data []byte) *TxRequest {
+	r.data = data
+	return r
+}
+
+// SetNetwork sets the network
+func (r *TxRequest) SetNetwork(network networks.Network) *TxRequest {
+	r.network = network
+	return r
+}
+
+// SetBeforeSignAndBroadcastHook sets the hook to be called before signing and broadcasting
+func (r *TxRequest) SetBeforeSignAndBroadcastHook(hook Hook) *TxRequest {
+	r.beforeSignAndBroadcastHook = hook
+	return r
+}
+
+// SetAfterSignAndBroadcastHook sets the hook to be called after signing and broadcasting
+func (r *TxRequest) SetAfterSignAndBroadcastHook(hook Hook) *TxRequest {
+	r.afterSignAndBroadcastHook = hook
+	return r
+}
+
+// execute executes the transaction request
+func (r *TxRequest) Execute() (*types.Transaction, error) {
+	return r.wm.EnsureTxWithHooks(
+		r.numRetries,
+		r.sleepDuration,
+		r.txType,
+		r.from,
+		r.to,
+		r.value,
+		r.gasLimit, r.extraGasLimit,
+		r.gasPrice, r.extraGasPrice,
+		r.tipCapGwei, r.extraTipCapGwei,
+		r.data,
+		r.network,
+		r.beforeSignAndBroadcastHook,
+		r.afterSignAndBroadcastHook,
+	)
+}

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,283 @@
+package walletarmy
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/tranvictor/jarvis/networks"
+)
+
+// MockHook for testing hooks
+func mockHook(tx *types.Transaction, err error) error {
+	return nil
+}
+
+func TestWalletManager_R(t *testing.T) {
+	wm := &WalletManager{}
+
+	req := wm.R()
+
+	assert.NotNil(t, req)
+	assert.Equal(t, wm, req.wm)
+	assert.Equal(t, big.NewInt(0), req.value)
+	assert.Equal(t, 0, req.numRetries)
+	assert.Equal(t, time.Duration(0), req.sleepDuration)
+	assert.Equal(t, uint8(0), req.txType)
+	assert.Equal(t, common.Address{}, req.from)
+	assert.Equal(t, common.Address{}, req.to)
+	assert.Equal(t, uint64(0), req.gasLimit)
+	assert.Equal(t, uint64(0), req.extraGasLimit)
+	assert.Equal(t, float64(0), req.gasPrice)
+	assert.Equal(t, float64(0), req.extraGasPrice)
+	assert.Equal(t, float64(0), req.tipCapGwei)
+	assert.Equal(t, float64(0), req.extraTipCapGwei)
+	assert.Nil(t, req.data)
+	assert.Equal(t, networks.EthereumMainnet, req.network)
+	assert.Nil(t, req.beforeSignAndBroadcastHook)
+	assert.Nil(t, req.afterSignAndBroadcastHook)
+}
+
+func TestTxRequest_SetNumRetries(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetNumRetries(5)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, 5, req.numRetries)
+}
+
+func TestTxRequest_SetSleepDuration(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+	duration := 2 * time.Second
+
+	result := req.SetSleepDuration(duration)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, duration, req.sleepDuration)
+}
+
+func TestTxRequest_SetTxType(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetTxType(2)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, uint8(2), req.txType)
+}
+
+func TestTxRequest_SetFrom(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+	fromAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	result := req.SetFrom(fromAddr)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, fromAddr, req.from)
+}
+
+func TestTxRequest_SetTo(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+	toAddr := common.HexToAddress("0x0987654321098765432109876543210987654321")
+
+	result := req.SetTo(toAddr)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, toAddr, req.to)
+}
+
+func TestTxRequest_SetValue(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	t.Run("with valid value", func(t *testing.T) {
+		value := big.NewInt(1000000000000000000) // 1 ETH in wei
+		result := req.SetValue(value)
+
+		assert.Equal(t, req, result) // Should return self for chaining
+		assert.Equal(t, value, req.value)
+	})
+
+	t.Run("with nil value", func(t *testing.T) {
+		originalValue := req.value
+		result := req.SetValue(nil)
+
+		assert.Equal(t, req, result)              // Should return self for chaining
+		assert.Equal(t, originalValue, req.value) // Should not change when nil
+	})
+}
+
+func TestTxRequest_SetGasLimit(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetGasLimit(21000)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, uint64(21000), req.gasLimit)
+}
+
+func TestTxRequest_SetExtraGasLimit(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetExtraGasLimit(5000)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, uint64(5000), req.extraGasLimit)
+}
+
+func TestTxRequest_SetGasPrice(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetGasPrice(20.5)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, 20.5, req.gasPrice)
+}
+
+func TestTxRequest_SetExtraGasPrice(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetExtraGasPrice(5.5)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, 5.5, req.extraGasPrice)
+}
+
+func TestTxRequest_SetTipCapGwei(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetTipCapGwei(2.0)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, 2.0, req.tipCapGwei)
+}
+
+func TestTxRequest_SetExtraTipCapGwei(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetExtraTipCapGwei(1.5)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, 1.5, req.extraTipCapGwei)
+}
+
+func TestTxRequest_SetData(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+	data := []byte{0x01, 0x02, 0x03, 0x04}
+
+	result := req.SetData(data)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, data, req.data)
+}
+
+func TestTxRequest_SetNetwork(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+	network := networks.EthereumMainnet
+
+	result := req.SetNetwork(network)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.Equal(t, network, req.network)
+}
+
+func TestTxRequest_SetBeforeSignAndBroadcastHook(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetBeforeSignAndBroadcastHook(mockHook)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.NotNil(t, req.beforeSignAndBroadcastHook)
+}
+
+func TestTxRequest_SetAfterSignAndBroadcastHook(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	result := req.SetAfterSignAndBroadcastHook(mockHook)
+
+	assert.Equal(t, req, result) // Should return self for chaining
+	assert.NotNil(t, req.afterSignAndBroadcastHook)
+}
+
+func TestTxRequest_BuilderPatternChaining(t *testing.T) {
+	wm := &WalletManager{}
+	fromAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	toAddr := common.HexToAddress("0x0987654321098765432109876543210987654321")
+	value := big.NewInt(1000000000000000000) // 1 ETH in wei
+	data := []byte{0x01, 0x02, 0x03, 0x04}
+	network := networks.EthereumMainnet
+	duration := 2 * time.Second
+
+	// Test chaining multiple methods together
+	req := wm.R().
+		SetNumRetries(3).
+		SetSleepDuration(duration).
+		SetTxType(2).
+		SetFrom(fromAddr).
+		SetTo(toAddr).
+		SetValue(value).
+		SetGasLimit(21000).
+		SetExtraGasLimit(1000).
+		SetGasPrice(20.5).
+		SetExtraGasPrice(5.0).
+		SetTipCapGwei(2.0).
+		SetExtraTipCapGwei(1.0).
+		SetData(data).
+		SetNetwork(network).
+		SetBeforeSignAndBroadcastHook(mockHook).
+		SetAfterSignAndBroadcastHook(mockHook)
+
+	// Verify all values were set correctly
+	assert.Equal(t, 3, req.numRetries)
+	assert.Equal(t, duration, req.sleepDuration)
+	assert.Equal(t, uint8(2), req.txType)
+	assert.Equal(t, fromAddr, req.from)
+	assert.Equal(t, toAddr, req.to)
+	assert.Equal(t, value, req.value)
+	assert.Equal(t, uint64(21000), req.gasLimit)
+	assert.Equal(t, uint64(1000), req.extraGasLimit)
+	assert.Equal(t, 20.5, req.gasPrice)
+	assert.Equal(t, 5.0, req.extraGasPrice)
+	assert.Equal(t, 2.0, req.tipCapGwei)
+	assert.Equal(t, 1.0, req.extraTipCapGwei)
+	assert.Equal(t, data, req.data)
+	assert.Equal(t, network, req.network)
+	assert.NotNil(t, req.beforeSignAndBroadcastHook)
+	assert.NotNil(t, req.afterSignAndBroadcastHook)
+}
+
+func TestTxRequest_MultipleSettersOfSameType(t *testing.T) {
+	wm := &WalletManager{}
+	req := wm.R()
+
+	// Test that calling the same setter multiple times overwrites the previous value
+	req.SetNumRetries(5).SetNumRetries(10).SetNumRetries(15)
+	assert.Equal(t, 15, req.numRetries)
+
+	req.SetGasPrice(10.0).SetGasPrice(20.0).SetGasPrice(30.0)
+	assert.Equal(t, 30.0, req.gasPrice)
+
+	value1 := big.NewInt(100)
+	value2 := big.NewInt(200)
+	value3 := big.NewInt(300)
+	req.SetValue(value1).SetValue(value2).SetValue(value3)
+	assert.Equal(t, value3, req.value)
+}


### PR DESCRIPTION
This PR does 2 things:
- Expose walletarmy request API using the builder pattern
- Allow client to set number of retries and the sleep duration

It keeps EnsureTx behavior the same to avoid breaking change