### PR TITLE
add gas estimation failed hook

### DIFF
--- a/error_decoder.go
+++ b/error_decoder.go
@@ -1,0 +1,79 @@
+// Author: https://github.com/piavgh
+
+package walletarmy
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type ErrorDecoder struct {
+	errorBySelector map[string]abi.Error // map from error selector to ABI error
+}
+
+func NewErrorDecoder(abis ...abi.ABI) (*ErrorDecoder, error) {
+	if len(abis) == 0 {
+		return nil, fmt.Errorf("at least one ABI must be provided")
+	}
+
+	errorBySelector := make(map[string]abi.Error)
+
+	for _, abi := range abis {
+		for _, err := range abi.Errors {
+			selector := hex.EncodeToString(err.ID[:4])
+			errorBySelector[selector] = err
+		}
+	}
+
+	return &ErrorDecoder{
+		errorBySelector: errorBySelector,
+	}, nil
+}
+
+// Decode decodes the error from a contract call.
+// It should always wrap the original error (using %w).
+// It can only decode Solidity custom errors https://soliditylang.org/blog/2021/04/21/custom-errors/
+func (d *ErrorDecoder) Decode(err error) error {
+	origErr := err
+	var dataErr rpc.DataError
+	if !errors.As(err, &dataErr) {
+		return fmt.Errorf("not a Solidity custom error: %w", err)
+	}
+
+	errorData := dataErr.ErrorData()
+	if errorData == nil {
+		return fmt.Errorf("no error data, original error: %w", origErr)
+	}
+
+	hexStr, ok := errorData.(string)
+	if !ok {
+		return fmt.Errorf("error data is not string, original error: %w", origErr)
+	}
+
+	hexStr = strings.TrimPrefix(hexStr, "0x")
+	errorBytes, decodeErr := hex.DecodeString(hexStr)
+	if decodeErr != nil {
+		return fmt.Errorf("failed to decode error data: %v, original error: %w", decodeErr, origErr)
+	}
+
+	if len(errorBytes) < 4 {
+		return fmt.Errorf("invalid error data length, original error: %w", origErr)
+	}
+
+	errorSelector := hex.EncodeToString(errorBytes[:4])
+	if abiError, exists := d.errorBySelector[errorSelector]; exists {
+		errParams, unpackErr := abiError.Unpack(errorBytes)
+		if unpackErr != nil {
+			return fmt.Errorf("failed to unpack error selector %s: %v, original error: %w", abiError.Name, unpackErr, origErr)
+		}
+
+		return fmt.Errorf("contract error: %s with params: %v, original error: %w", abiError.Name, errParams, origErr)
+	}
+
+	return fmt.Errorf("unknown error: 0x%s, original error: %w", errorSelector, origErr)
+}

--- a/hook.go
+++ b/hook.go
@@ -1,5 +1,17 @@
 package walletarmy
 
-import "github.com/ethereum/go-ethereum/core/types"
+import (
+	"math/big"
 
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Hook is a function that is called before and after a transaction is signed and broadcasted
 type Hook func(tx *types.Transaction, err error) error
+
+// ContractRevertHook is a function that is called when a transaction is failed to estimate gas
+// revertMsg is the revert message returned by the contract and parsed with the abi passed in the tx request
+// This hook will NOT be called if the tx request doesn't have any abis set
+// If the hook returns a non-nil gas limit, the gas limit will be used to do the next iteration
+// The hook should return an error to stop the loop and return the error
+type GasEstimationFailedHook func(tx *types.Transaction, revertMsgError, gasEstimationError error) (gasLimit *big.Int, err error)

--- a/request.go
+++ b/request.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/tranvictor/jarvis/networks"
@@ -32,6 +33,8 @@ type TxRequest struct {
 	// Hooks
 	beforeSignAndBroadcastHook Hook
 	afterSignAndBroadcastHook  Hook
+	gasEstimationFailedHook    GasEstimationFailedHook
+	abis                       []abi.ABI
 }
 
 // R creates a new transaction request (similar to go-resty's R() method)
@@ -129,6 +132,12 @@ func (r *TxRequest) SetNetwork(network networks.Network) *TxRequest {
 	return r
 }
 
+// SetAbis sets the abis
+func (r *TxRequest) SetAbis(abis ...abi.ABI) *TxRequest {
+	r.abis = abis
+	return r
+}
+
 // SetBeforeSignAndBroadcastHook sets the hook to be called before signing and broadcasting
 func (r *TxRequest) SetBeforeSignAndBroadcastHook(hook Hook) *TxRequest {
 	r.beforeSignAndBroadcastHook = hook
@@ -138,6 +147,12 @@ func (r *TxRequest) SetBeforeSignAndBroadcastHook(hook Hook) *TxRequest {
 // SetAfterSignAndBroadcastHook sets the hook to be called after signing and broadcasting
 func (r *TxRequest) SetAfterSignAndBroadcastHook(hook Hook) *TxRequest {
 	r.afterSignAndBroadcastHook = hook
+	return r
+}
+
+// SetGasEstimationFailedHook sets the hook to be called when gas estimation fails
+func (r *TxRequest) SetGasEstimationFailedHook(hook GasEstimationFailedHook) *TxRequest {
+	r.gasEstimationFailedHook = hook
 	return r
 }
 
@@ -157,5 +172,7 @@ func (r *TxRequest) Execute() (*types.Transaction, error) {
 		r.network,
 		r.beforeSignAndBroadcastHook,
 		r.afterSignAndBroadcastHook,
+		r.abis,
+		r.gasEstimationFailedHook,
 	)
 }

--- a/wallet_manager.go
+++ b/wallet_manager.go
@@ -650,8 +650,7 @@ func (wm *WalletManager) EnsureTxWithHooks(
 			} else {
 				// if it is mined, we don't need to do anything, just stop the loop and return
 				for txhash, status := range statuses {
-					switch status.Status {
-					case "done", "reverted":
+					if status.Status == "done" || status.Status == "reverted" {
 						return oldTxs[txhash], nil
 					}
 				}
@@ -660,8 +659,7 @@ func (wm *WalletManager) EnsureTxWithHooks(
 				// with the highest gas price
 				highestGasPrice := big.NewInt(0)
 				for txhash, status := range statuses {
-					switch status.Status {
-					case "pending":
+					if status.Status == "pending" {
 						if oldTxs[txhash].GasPrice().Cmp(highestGasPrice) > 0 {
 							highestGasPrice = oldTxs[txhash].GasPrice()
 							signedTx = oldTxs[txhash]
@@ -738,8 +736,7 @@ func (wm *WalletManager) EnsureTxWithHooks(
 				}
 				// if it is mined, we don't need to do anything, just stop the loop and return
 				for txhash, status := range statuses {
-					switch status.Status {
-					case "done", "reverted":
+					if status.Status == "done" || status.Status == "reverted" {
 						return oldTxs[txhash], nil
 					}
 				}


### PR DESCRIPTION
1. add hook to handle gas estimation failure error
2. parse contract revert message toward abis

```golang
// ContractRevertHook is a function that is called when a transaction is failed to estimate gas
// revertMsg is the revert message returned by the contract and parsed with the abi passed in the tx request
// This hook will NOT be called if the tx request doesn't have any abis set
// If the hook returns a non-nil gas limit, the gas limit will be used to do the next iteration
// The hook should return an error to stop the loop and return the error
type GasEstimationFailedHook func(tx *types.Transaction, revertMsgError, gasEstimationError error) (gasLimit *big.Int, err error)
```