### PR TITLE
fix: 2 goroutines acquire the same nonce

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/KyberNetwork/logger v0.2.1
 	github.com/ethereum/go-ethereum v1.16.8
 	github.com/stretchr/testify v1.10.0
-	github.com/tranvictor/jarvis v0.0.37-0.20251101033912-bd3c6e73687a
+	github.com/tranvictor/jarvis v0.0.37-0.20260226112729-7971a281e1d9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/tranvictor/jarvis v0.0.37-0.20251101033912-bd3c6e73687a h1:xd3FBWwkIOKsrSG3PJzmtEy3o/VkDokfD56NMk6vDXI=
-github.com/tranvictor/jarvis v0.0.37-0.20251101033912-bd3c6e73687a/go.mod h1:WqkYMHG59ENXa6RciEHFzAmCOfjl6XBln0thA6Xm/kg=
+github.com/tranvictor/jarvis v0.0.37-0.20260226112729-7971a281e1d9 h1:caMMIF82JPgKTcpdkYM+LOT/yHpDTHNk76Ly4zcEkug=
+github.com/tranvictor/jarvis v0.0.37-0.20260226112729-7971a281e1d9/go.mod h1:WqkYMHG59ENXa6RciEHFzAmCOfjl6XBln0thA6Xm/kg=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=

--- a/internal/nonce/tracker.go
+++ b/internal/nonce/tracker.go
@@ -19,9 +19,10 @@ type Tracker struct {
 	// walletLocks provides per-wallet locking
 	walletLocks sync.Map // map[common.Address]*sync.RWMutex
 
-	// claimedGaps tracks gap nonces that have been claimed by AcquireNonce
-	// but not yet confirmed (i.e., not yet in TxStore). This prevents two
-	// sequential callers under the same lock from both claiming the same gap.
+	// claimedGaps tracks nonces that have been acquired by AcquireNonce but
+	// not yet broadcast (i.e., not yet in TxStore). This prevents the gap
+	// finder from re-issuing a nonce that is currently being processed.
+	// Entries are added in AcquireNonce and removed in ReleaseNonce.
 	// Structure: wallet -> (chainID -> set of claimed nonces)
 	// MUST be accessed with wallet lock held.
 	claimedGaps sync.Map // map[common.Address]map[uint64]map[uint64]bool
@@ -49,10 +50,17 @@ func (t *Tracker) getClaimedGaps(wallet common.Address, chainID uint64) map[uint
 	return chainGaps[chainID]
 }
 
-// claimGap marks a gap nonce as claimed. MUST be called with wallet lock held.
+// claimGap marks a nonce as claimed. MUST be called with wallet lock held.
 func (t *Tracker) claimGap(wallet common.Address, chainID uint64, nonce uint64) {
 	gaps := t.getClaimedGaps(wallet, chainID)
 	gaps[nonce] = true
+}
+
+// unclaimGap removes a nonce from the claimed set, allowing the gap finder to
+// reclaim it. MUST be called with wallet lock held.
+func (t *Tracker) unclaimGap(wallet common.Address, chainID uint64, nonce uint64) {
+	gaps := t.getClaimedGaps(wallet, chainID)
+	delete(gaps, nonce)
 }
 
 // getOrCreateNonceMap returns the nonce map for a wallet, creating it if necessary.
@@ -262,6 +270,10 @@ func (t *Tracker) AcquireNonce(
 	// This ensures the next call to AcquireNonce will get nextNonce+1
 	t.SetPendingNonceUnlocked(wallet, chainID, networkName, nextNonce)
 
+	// Also mark this nonce as claimed so the gap finder won't re-issue it
+	// before the transaction is broadcast and recorded in TxStore.
+	t.claimGap(wallet, chainID, nextNonce)
+
 	var localNonceStr string
 	if localPendingNonceBig != nil {
 		localNonceStr = localPendingNonceBig.String()
@@ -294,6 +306,10 @@ func (t *Tracker) ReleaseNonce(wallet common.Address, chainID uint64, networkNam
 	lock := t.getWalletLock(wallet)
 	lock.Lock()
 	defer lock.Unlock()
+
+	// Always unclaim the nonce so the gap finder can reclaim it.
+	// This is safe even if the nonce was never in claimedGaps.
+	t.unclaimGap(wallet, chainID, nonce)
 
 	noncesRaw, ok := t.pendingNonces.Load(wallet)
 	if !ok {

--- a/internal/nonce/tracker_test.go
+++ b/internal/nonce/tracker_test.go
@@ -490,6 +490,181 @@ func TestTracker_ConcurrentAcquireRelease(t *testing.T) {
 	// Test passes if no race condition occurs
 }
 
+// TestTracker_AcquireNonce_NormalPathPreventsGapFinderReissue reproduces the nonce
+// collision bug where two concurrent callers could acquire the same nonce:
+//
+//  1. Swap acquires nonce 9859 via normal path (mined=remotePending=9859)
+//  2. Sweep enters AcquireNonce with the same remote nonces (fetched before swap broadcast)
+//  3. Gap finder scans [9859, 9860) — should NOT re-issue 9859
+//
+// Before the fix, the gap finder would see 9859 as a "gap" because:
+//   - It wasn't in claimedGaps (only gap-filled nonces were tracked)
+//   - It wasn't in TxStore yet (swap hadn't broadcast)
+//
+// After the fix, the normal path also calls claimGap, so the gap finder skips 9859.
+func TestTracker_AcquireNonce_NormalPathPreventsGapFinderReissue(t *testing.T) {
+	tracker := NewTracker()
+	wallet := common.HexToAddress("0x108683b62B1C5fFE60D4d0CC9c249FD92e30a403")
+	chainID := uint64(8453)
+	networkName := "base"
+
+	// Initial state: local pending nonce = 9858 (as in the production logs)
+	tracker.SetPendingNonce(wallet, chainID, networkName, 9858)
+
+	// Gap finder that simulates an empty TxStore — reports every unclaimed nonce as a gap.
+	// This is what happens when the first tx hasn't been broadcast/persisted yet.
+	emptyTxStore := func(_ common.Address, _ uint64, from, to uint64, claimed map[uint64]bool) (uint64, bool) {
+		for n := from; n < to; n++ {
+			if !claimed[n] {
+				return n, true
+			}
+		}
+		return 0, false
+	}
+
+	// Both goroutines fetch the same stale remote nonces before entering the lock
+	minedNonce := uint64(9859)
+	remotePending := uint64(9859)
+
+	var wg sync.WaitGroup
+	results := make(chan uint64, 2)
+	start := make(chan struct{}) // ensures both goroutines start simultaneously
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // wait for the signal
+			result, err := tracker.AcquireNonce(wallet, chainID, networkName, minedNonce, remotePending, emptyTxStore)
+			if err != nil {
+				t.Errorf("acquire failed: %v", err)
+				return
+			}
+			results <- result.Nonce
+		}()
+	}
+
+	close(start) // release both goroutines at the same time
+	wg.Wait()
+	close(results)
+
+	nonces := make([]uint64, 0, 2)
+	for n := range results {
+		nonces = append(nonces, n)
+	}
+
+	if len(nonces) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(nonces))
+	}
+	if nonces[0] == nonces[1] {
+		t.Fatalf("NONCE COLLISION: both goroutines acquired nonce %d", nonces[0])
+	}
+}
+
+// TestTracker_AcquireNonce_ReleasedNonceCanBeReclaimed verifies that when a nonce
+// is acquired via the normal path but then released (tx failed before broadcast),
+// the gap finder can reclaim it.
+func TestTracker_AcquireNonce_ReleasedNonceCanBeReclaimed(t *testing.T) {
+	tracker := NewTracker()
+	wallet := common.HexToAddress("0x108683b62B1C5fFE60D4d0CC9c249FD92e30a403")
+	chainID := uint64(8453)
+	networkName := "base"
+
+	emptyTxStore := func(_ common.Address, _ uint64, from, to uint64, claimed map[uint64]bool) (uint64, bool) {
+		for n := from; n < to; n++ {
+			if !claimed[n] {
+				return n, true
+			}
+		}
+		return 0, false
+	}
+
+	// Acquire two nonces: 100 and 101
+	r1, _ := tracker.AcquireNonce(wallet, chainID, networkName, 100, 100, emptyTxStore)
+	r2, _ := tracker.AcquireNonce(wallet, chainID, networkName, 100, 100, emptyTxStore)
+	if r1.Nonce != 100 || r2.Nonce != 101 {
+		t.Fatalf("expected nonces 100 and 101, got %d and %d", r1.Nonce, r2.Nonce)
+	}
+
+	// Nonce 100's tx fails before broadcast → release it.
+	// ReleaseNonce can't roll back pendingNonces (100 is not the tip, 101 is),
+	// but it MUST unclaim it from claimedGaps so the gap finder can reclaim it.
+	tracker.ReleaseNonce(wallet, chainID, networkName, 100)
+
+	// Next acquire: gap finder should reclaim nonce 100
+	// localPending=102, remotePending=100, gap finder scans [100, 102)
+	// Nonce 100: not in claimedGaps (released) → gap found
+	// Nonce 101: in claimedGaps (not released) → skipped
+	r3, err := tracker.AcquireNonce(wallet, chainID, networkName, 100, 100, emptyTxStore)
+	if err != nil {
+		t.Fatalf("reclaim acquire failed: %v", err)
+	}
+	if r3.Nonce != 100 {
+		t.Errorf("expected reclaimed nonce 100, got %d", r3.Nonce)
+	}
+	if r3.DecisionReason != "gap fill" {
+		t.Errorf("expected 'gap fill' decision, got %q", r3.DecisionReason)
+	}
+}
+
+// TestTracker_AcquireNonce_ConcurrentNoDuplicateNonces verifies that many concurrent
+// callers for the same wallet never receive the same nonce, even when all see
+// stale remote state (the production race condition with 20 goroutines).
+func TestTracker_AcquireNonce_ConcurrentNoDuplicateNonces(t *testing.T) {
+	tracker := NewTracker()
+	wallet := common.HexToAddress("0x108683b62B1C5fFE60D4d0CC9c249FD92e30a403")
+	chainID := uint64(8453)
+	networkName := "base"
+
+	tracker.SetPendingNonce(wallet, chainID, networkName, 9858)
+
+	emptyTxStore := func(_ common.Address, _ uint64, from, to uint64, claimed map[uint64]bool) (uint64, bool) {
+		for n := from; n < to; n++ {
+			if !claimed[n] {
+				return n, true
+			}
+		}
+		return 0, false
+	}
+
+	numGoroutines := 20
+	results := make(chan uint64, numGoroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// All goroutines use the same stale remote nonces (mined=9859, remotePending=9859),
+	// simulating the case where all fetched remote state before any tx was broadcast.
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := tracker.AcquireNonce(wallet, chainID, networkName, 9859, 9859, emptyTxStore)
+			if err != nil {
+				t.Errorf("acquire failed: %v", err)
+				return
+			}
+			results <- result.Nonce
+		}()
+	}
+
+	close(start) // release all goroutines at the same time
+	wg.Wait()
+	close(results)
+
+	seen := make(map[uint64]bool)
+	for nonce := range results {
+		if seen[nonce] {
+			t.Fatalf("NONCE COLLISION: nonce %d was acquired by multiple goroutines", nonce)
+		}
+		seen[nonce] = true
+	}
+
+	if len(seen) != numGoroutines {
+		t.Fatalf("expected %d unique nonces, got %d", numGoroutines, len(seen))
+	}
+}
+
 func TestTracker_AcquireNonce_EqualNonces(t *testing.T) {
 	tracker := NewTracker()
 	wallet := common.HexToAddress("0x0234567890123456789012345678901234567890")

--- a/manager_nonce.go
+++ b/manager_nonce.go
@@ -128,28 +128,48 @@ func (wm *WalletManager) persistNonceAcquisition(wallet common.Address, chainID 
 	_ = wm.nonceStore.SavePendingNonce(ctx, wallet, chainID, nonce)
 }
 
-// isBlockingNonce checks whether the given nonce is the next nonce the chain
-// expects to process. A blocking nonce is one that equals the current mined nonce —
-// it must be confirmed before any higher-nonce transactions can proceed.
-//
-// Since gas bumping is only applied to this single transaction (not all queued txs),
-// users should set gas protection limits aggressively enough for the blocking nonce.
-//
-// If we can't determine the chain state (reader error), we assume it's not blocking
-// to avoid being overly aggressive with gas.
-func (wm *WalletManager) isBlockingNonce(nonce uint64, wallet common.Address, network networks.Network) bool {
+// nonceStatus describes the state of a nonce relative to the chain's mined nonce.
+type nonceStatus int
+
+const (
+	// nonceStatusUnknown means we couldn't determine the chain state (RPC error).
+	nonceStatusUnknown nonceStatus = iota
+	// nonceStatusBlocking means the nonce equals the mined nonce — it must be confirmed
+	// before any higher-nonce transactions can proceed.
+	nonceStatusBlocking
+	// nonceStatusPending means the nonce is higher than the mined nonce — there are
+	// earlier nonces that must be confirmed first.
+	nonceStatusPending
+	// nonceStatusConsumed means the nonce is lower than the mined nonce — another
+	// transaction with this nonce has already been mined. This transaction can never
+	// be included.
+	nonceStatusConsumed
+)
+
+// getNonceStatus determines the state of a nonce relative to the chain.
+func (wm *WalletManager) getNonceStatus(nonce uint64, wallet common.Address, network networks.Network) nonceStatus {
+	if network == nil {
+		return nonceStatusUnknown
+	}
 	r, err := wm.Reader(network)
 	if err != nil {
-		return false
+		return nonceStatusUnknown
 	}
 
 	minedNonce, err := r.GetMinedNonce(wallet.Hex())
 	if err != nil {
-		return false
+		return nonceStatusUnknown
 	}
 
-	return nonce == minedNonce
+	if nonce < minedNonce {
+		return nonceStatusConsumed
+	}
+	if nonce == minedNonce {
+		return nonceStatusBlocking
+	}
+	return nonceStatusPending
 }
+
 
 // persistNonceRelease persists a nonce release to the nonce store
 func (wm *WalletManager) persistNonceRelease(wallet common.Address, chainID uint64, nonce uint64) {

--- a/manager_tx.go
+++ b/manager_tx.go
@@ -1209,6 +1209,21 @@ func (wm *WalletManager) handleTransactionStatus(status TxInfo, signedTx *types.
 		return wm.handleMinedTx(signedTx, status, execCtx)
 
 	case TxStatusLost:
+		// If the nonce is already consumed, no point retrying — another tx with
+		// this nonce has been mined.
+		if wm.getNonceStatus(signedTx.Nonce(), execCtx.Params.From, execCtx.Params.Network) == nonceStatusConsumed {
+			logger.WithFields(logger.Fields{
+				"tx_hash": signedTx.Hash().Hex(),
+				"nonce":   signedTx.Nonce(),
+			}).Warn("Transaction lost and nonce already consumed by another transaction, giving up")
+
+			return &TxExecutionResult{
+				Transaction: signedTx,
+				Action:      ActionReturn,
+				Error:       fmt.Errorf("nonce %d already consumed by another transaction", signedTx.Nonce()),
+			}
+		}
+
 		// Transaction was dropped from the mempool. Re-broadcast with the same nonce
 		// and higher gas, similar to the "slow" handler. Acquiring a new nonce would
 		// create a gap that can never be filled.
@@ -1238,10 +1253,28 @@ func (wm *WalletManager) handleTransactionStatus(status TxInfo, signedTx *types.
 		}
 
 	case TxStatusSlow:
+		// Check the nonce state to decide how to handle the slow tx.
+		nStatus := wm.getNonceStatus(signedTx.Nonce(), execCtx.Params.From, execCtx.Params.Network)
+
+		if nStatus == nonceStatusConsumed {
+			// Another transaction with this nonce has already been mined.
+			// This tx can never be included — stop waiting immediately.
+			logger.WithFields(logger.Fields{
+				"tx_hash": signedTx.Hash().Hex(),
+				"nonce":   signedTx.Nonce(),
+			}).Warn("Transaction's nonce has been consumed by another transaction, giving up")
+
+			return &TxExecutionResult{
+				Transaction: signedTx,
+				Action:      ActionReturn,
+				Error:       fmt.Errorf("nonce %d already consumed by another transaction", signedTx.Nonce()),
+			}
+		}
+
 		// Only bump gas if this nonce is blocking higher-nonce transactions.
 		// Non-blocking slow txs just keep waiting — they'll get mined once
 		// the blocking nonce ahead of them is resolved.
-		if !wm.isBlockingNonce(signedTx.Nonce(), execCtx.Params.From, execCtx.Params.Network) {
+		if nStatus != nonceStatusBlocking {
 			logger.WithFields(logger.Fields{
 				"tx_hash": signedTx.Hash().Hex(),
 				"nonce":   signedTx.Nonce(),


### PR DESCRIPTION
- Introduced a new `nonceStatus` type to better represent the state of nonces relative to the chain's mined nonce.
- Replaced the `isBlockingNonce` function with `getNonceStatus` for improved clarity and functionality.
- Updated transaction handling logic to account for consumed nonces, preventing retries on lost transactions with already consumed nonces.
- Enhanced the nonce tracking mechanism to ensure claimed gaps are properly managed during nonce acquisition and release.